### PR TITLE
remove 'd' and 'u' shortcut

### DIFF
--- a/background-script.js
+++ b/background-script.js
@@ -1,8 +1,0 @@
-chrome.runtime.onMessage.addListener(cmd => {
-  switch(cmd){
-    case 'u':
-      browser.sessions.getRecentlyClosed({maxResults: 1})
-        .then(s => browser.sessions.restore(s[0].sessionId))
-    break;
-  }
-})

--- a/background-script.js
+++ b/background-script.js
@@ -1,9 +1,5 @@
 chrome.runtime.onMessage.addListener(cmd => {
   switch(cmd){
-    case 'd':
-      browser.tabs.query({currentWindow: true, active: true})
-        .then(tab => browser.tabs.remove(tab[0].id))
-    break;
     case 'u':
       browser.sessions.getRecentlyClosed({maxResults: 1})
         .then(s => browser.sessions.restore(s[0].sessionId))

--- a/content-script.js
+++ b/content-script.js
@@ -7,6 +7,5 @@ addEventListener('keydown', event => {
     case 'h': history.back(); break;
     case 'l': history.forward(); break;
     case 'u': chrome.runtime.sendMessage('u'); break;
-    case 'd': chrome.runtime.sendMessage('d'); break;
   }
 })

--- a/content-script.js
+++ b/content-script.js
@@ -6,6 +6,5 @@ addEventListener('keydown', event => {
     case 'k': scrollBy(0, -50); break;
     case 'h': history.back(); break;
     case 'l': history.forward(); break;
-    case 'u': chrome.runtime.sendMessage('u'); break;
   }
 })

--- a/create-extension.sh
+++ b/create-extension.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-zip jk-extension.zip background-script.js content-script.js manifest.json
+zip jk-extension.zip content-script.js manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,6 @@
     "js": ["content-script.js"],
     "run_at": "document_end"
   }],
-  "background": {
-    "scripts": ["background-script.js"]
-  },
   "browser_specific_settings": {
     "gecko": {
       "id": "jkscroll@h43z"


### PR DESCRIPTION
The 'd' shortcut interferes with Ctrl-d which I frequently use to mute/unmute myself on Google Meet. Since Ctrl-w exists for closing window which is easy enough, having `d` isn't a value-add.

Ctrl-Shift-T does the same job of re-opening the previously closed tab and is supported by default.

Side note: I really liked the super simplicity of what repository does and I am personally using this extension. Love it, Thank you so much for developing this.