### PR TITLE
also ignore alt and meta modifiers

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -61,8 +61,7 @@ addEventListener('keydown', event => {
   if(localStorage.getItem('jkdisable')) return
 
   // don't hook into native browser shortcuts
-  // most of them are done with ctrl
-  if(event.ctrlKey) return
+  if(event.ctrlKey || event.altKey || event.metaKey) return
 
   // only continue if a key from defined actions is pressed
   if(!actions[event.key]) return


### PR DESCRIPTION
Currently, the extension eats all conflicting shortcuts using alt or meta modifiers (option and cmd on macOS). This includes `cmd+L` to select the address bar.

This PR ignores keydown events with those modifiers held.