### PR TITLE
Properly handling ctrl key

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -57,7 +57,7 @@ addEventListener('keydown', event => {
   if(
     event.altKey ||
     event.metaKey ||
-    event.ctrlKey ||
+    (event.ctrlKey && event.key !== 'c') ||
     event.key === 'AltGraph' ||
     event.key === 'Alt'
   )

--- a/content-script.js
+++ b/content-script.js
@@ -57,9 +57,7 @@ addEventListener('keydown', event => {
   if(
     event.altKey ||
     event.metaKey ||
-    (event.ctrlKey && event.key !== 'c') ||
-    event.key === 'AltGraph' ||
-    event.key === 'Alt'
+    (event.ctrlKey && event.key !== 'c')
   )
     return
 

--- a/content-script.js
+++ b/content-script.js
@@ -57,7 +57,7 @@ addEventListener('keydown', event => {
   if(
     event.altKey ||
     event.metaKey ||
-    event.key === 'Control' ||
+    event.ctrlKey ||
     event.key === 'AltGraph' ||
     event.key === 'Alt'
   )


### PR DESCRIPTION
In my computer (Firefox on Linux), the extension currently hooks into the shortcuts done with the Control modifier.

I think the problem is that when hitting C-[key], two separate events are created, one for the control key and one for [key].

This PR fixes this behaviour.